### PR TITLE
Set node child_process method maxbuffer to 15mb

### DIFF
--- a/src/stages/run-local-shell-command.js
+++ b/src/stages/run-local-shell-command.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// 15.36MB
+const MAX_BUFFER = 15000 * 1024
+
 let exec = require('child_process').exec
 let shellCommandLog = require('../logs/shell-command')
 
@@ -45,7 +48,10 @@ module.exports = {
 
     stage.log('Running shell command')
 
-    exec(commands, {timeout: timeout}, function (err, stdout, stderr) {
+    exec(commands, {
+    	timeout: timeout,
+    	maxBuffer: MAX_BUFFER
+    }, function (err, stdout, stderr) {
 
       let exitCode = (err !== null) ? err.code : 0
 


### PR DESCRIPTION
With the packer command we were reaching the default `maxBuffer` limit for the node [`child_process.exec` command](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback).