### PR TITLE
Adding basic remote shell stage type (Closes #5)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ module.exports = {
   description: 'A collection of basic stage types and utilities included with Mission Control.',
   stages: [
     require('./src/stages/pause-for-x-seconds'),
-    require('./src/stages/run-local-shell-command')
+    require('./src/stages/run-local-shell-command'),
+    require('./src/stages/run-remote-shell-command')
   ],
   logs: [
     require('./src/logs/snippet'),

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "author": "",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "ssh-exec": "^1.4.0"
+  },
   "devDependencies": {
     "mc-extension-validator": "*",
     "tape": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "ssh-exec": "git@github.com:andyfleming/ssh-exec.git#77025d4"
+    "ssh-exec": "https://github.com/andyfleming/ssh-exec.git#77025d4"
   },
   "devDependencies": {
     "mc-extension-validator": "*",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "ssh-exec": "git@github.com:andyfleming/ssh-exec.git#984d2ec"
+    "ssh-exec": "git@github.com:andyfleming/ssh-exec.git#77025d4"
   },
   "devDependencies": {
     "mc-extension-validator": "*",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "ssh-exec": "^1.4.0"
+    "ssh-exec": "git@github.com:andyfleming/ssh-exec.git#984d2ec"
   },
   "devDependencies": {
     "mc-extension-validator": "*",

--- a/src/stages/run-remote-shell-command.js
+++ b/src/stages/run-remote-shell-command.js
@@ -20,7 +20,7 @@ module.exports = {
       name: 'Host',
       description: "Address of remote host to run command on",
       required: true,
-      type: 'textarea'
+      type: 'text'
     },
     port: {
       name: 'Port',

--- a/src/stages/run-remote-shell-command.js
+++ b/src/stages/run-remote-shell-command.js
@@ -1,0 +1,86 @@
+'use strict'
+
+let sshExec = require('ssh-exec')
+
+module.exports = {
+
+  id: 'run_remote_shell_command',
+  name: 'Run Remote Shell Command(s)',
+  description: 'Runs one or more commands on a remote server via SSH.',
+  icon: '/extensions/mc/basics/icons/run_remote_shell_command.svg',
+
+  options: {
+    user: {
+      name: 'User',
+      description: 'User for the remote host',
+      required: true,
+      type: 'text'
+    },
+    host: {
+      name: 'Host',
+      description: "Address of remote host to run command on",
+      required: true,
+      type: 'textarea'
+    },
+    port: {
+      name: 'Port',
+      description: 'Port to connect to',
+      required: true,
+      type: 'text',
+      default: '22'
+    },
+    commands: {
+      name: 'Command(s)',
+      description: "Command(s) to run",
+      required: true,
+      type: 'textarea'
+    }
+  },
+
+  outputs: {
+    stdout: {
+      description: 'Output from command'
+    },
+    stderr: {
+      description: 'Error output from command'
+    },
+    exit_code: {
+      description: 'Exit code after execution'
+    }
+  },
+
+  execute: function(stage) {
+
+    let commands = stage.option('commands')
+
+    let options = {
+      host: stage.option('host'),
+      user: stage.option('user'),
+      port: stage.option('port')
+      //key: '',
+      //password: ''
+    }
+
+    stage.log('Running remote shell command')
+
+    sshExec(commands, options, (err, stdout, stderr) => {
+      let exitCode = (err !== null) ? err.code : 0
+
+      stage.log('mc.basics.logs.shell_command', 'Remote shell command execution completed.', [stdout, stderr, exitCode])
+
+      if (err !== null) {
+        stage.fail()
+      } else {
+        stage.output({
+          stdout: stdout,
+          stderr: stderr,
+          exit_code: exitCode
+        })
+        stage.succeed()
+      }
+    })
+
+
+  }
+
+}


### PR DESCRIPTION
This works on a basic level but needs some love before being merged in.

A few things that should be done:
- [x] Options need reviewed
- [x] Testing of if exit code is actually properly captured (which I don't think it is currently)
  - [x] If it doesn't capture exit code now, considering some strategy for capturing it